### PR TITLE
Validate availability of only the quantity to be added to the line_item.

### DIFF
--- a/app/models/spree/stock/availability_validator.rb
+++ b/app/models/spree/stock/availability_validator.rb
@@ -3,14 +3,17 @@ module Spree
     # Overridden from spree core to make it also check for assembly parts stock
     class AvailabilityValidator < ActiveModel::Validator
       def validate(line_item)
+        unit_count = line_item.inventory_units.size  
+        return if unit_count >= line_item.quantity
+        
         product = line_item.product
 
         valid = if product.assembly?
           line_item.parts.all? do |part|
-            Stock::Quantifier.new(part).can_supply?(line_item.count_of(part) * line_item.quantity)
+            Stock::Quantifier.new(part).can_supply?(line_item.count_of(part) * (line_item.quantity - unit_count))
           end
         else
-          Stock::Quantifier.new(line_item.variant).can_supply? line_item.quantity
+          Stock::Quantifier.new(line_item.variant).can_supply?(line_item.quantity - unit_count)
         end
 
         unless valid


### PR DESCRIPTION
Only need to check that a sufficient quantity of parts is available to cover quantity added to the line_item, not the entire quantity of the line_item.
